### PR TITLE
Fix deadlock in ffplay process output handling

### DIFF
--- a/Sources/PiTalk/PiTalkApp.swift
+++ b/Sources/PiTalk/PiTalkApp.swift
@@ -1350,6 +1350,8 @@ final class SpeechPlaybackCoordinator {
         process.executableURL = URL(fileURLWithPath: ffplayPath)
         let inputPipe = Pipe()
         process.standardInput = inputPipe
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
 
         var arguments = [
             "-f", "s16le",
@@ -1804,9 +1806,27 @@ final class SpeechPlaybackCoordinator {
         probe.standardError = err
 
         if (try? probe.run()) != nil {
+            // Read pipes on background threads BEFORE waitUntilExit to avoid
+            // deadlock when output exceeds the pipe buffer (~16 KB on macOS).
+            // ffplay -h full easily produces 100 KB+.
+            var outputData = Data()
+            var errorData = Data()
+            let group = DispatchGroup()
+            group.enter()
+            DispatchQueue.global().async {
+                outputData = out.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+            group.enter()
+            DispatchQueue.global().async {
+                errorData = err.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
             probe.waitUntilExit()
-            var output = out.fileHandleForReading.readDataToEndOfFile()
-            output.append(err.fileHandleForReading.readDataToEndOfFile())
+            group.wait()
+
+            var output = outputData
+            output.append(errorData)
             if let text = String(data: output, encoding: .utf8) {
                 if text.contains("-ch_layout") {
                     detected = ["-ch_layout", "mono"]


### PR DESCRIPTION
## Summary
Fixed a potential deadlock in the `SpeechPlaybackCoordinator` when reading output from ffplay processes by reading pipes on background threads before waiting for process exit.

## Key Changes
- **Suppress ffplay output**: Redirect stdout and stderr to `/dev/null` for the main audio playback process to reduce unnecessary I/O
- **Fix probe process deadlock**: Refactored pipe reading in the ffplay probe process to use background threads with `DispatchGroup`:
  - Read stdout and stderr on separate background threads concurrently
  - Wait for process exit and background reads to complete before accessing the data
  - Prevents deadlock when ffplay output exceeds the pipe buffer (~16 KB on macOS)

## Implementation Details
The deadlock occurred because `waitUntilExit()` was called before reading the pipes. When ffplay's output (especially from `ffplay -h full`) exceeds the pipe buffer capacity, the process blocks waiting for the pipe to be drained while the main thread is blocked waiting for the process to exit.

The fix uses `DispatchGroup` to coordinate reading both stdout and stderr on background threads concurrently, ensuring pipes are drained before the main thread waits for process exit.

https://claude.ai/code/session_01Gxc2ttmYwcUiawjke2d85R